### PR TITLE
Update macOS CI images to `macos-14`.

### DIFF
--- a/.github/workflows/build-ubuntu20.04-backwards-compatibility.yml
+++ b/.github/workflows/build-ubuntu20.04-backwards-compatibility.yml
@@ -26,7 +26,7 @@ jobs:
       # Need this for virtualenv and arrow tests if enabled
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: '3.8'
       - run: |
           set -e pipefail
           python -m pip install --upgrade pip virtualenv

--- a/.github/workflows/ci-linux_mac.yml
+++ b/.github/workflows/ci-linux_mac.yml
@@ -51,6 +51,11 @@ on:
         description: 'Enable manylinux builds'
         required: false
         type: boolean
+      vcpkg_base_triplet:
+        default: ''
+        description: 'Base triplet for vcpkg'
+        required: false
+        type: string
 
 env:
   BACKWARDS_COMPATIBILITY_ARRAYS: OFF
@@ -63,7 +68,7 @@ env:
   CC: ${{ inputs.matrix_compiler_cc }}
   CFLAGS: ${{ inputs.matrix_compiler_cflags }}
   CXXFLAGS: ${{ inputs.matrix_compiler_cxxflags }}
-  bootstrap_args: "--enable-ccache --vcpkg-base-triplet=x64-${{ startsWith(inputs.matrix_image, 'ubuntu-') && 'linux' || 'osx' }} ${{ inputs.bootstrap_args }} ${{ inputs.asan && '--enable-sanitizer=address' || '' }}"
+  bootstrap_args: "--enable-ccache --vcpkg-base-triplet=${{ inputs.vcpkg_base_triplet || (startsWith(inputs.matrix_image, 'ubuntu-') && 'x64-linux' || 'x64-osx') }} ${{ inputs.bootstrap_args }} ${{ inputs.asan && '--enable-sanitizer=address' || '' }}"
   VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
   SCCACHE_GHA_ENABLED: "true"
 

--- a/.github/workflows/ci-linux_mac.yml
+++ b/.github/workflows/ci-linux_mac.yml
@@ -56,9 +56,15 @@ on:
         description: 'Base triplet for vcpkg'
         required: false
         type: string
+      cmake_generator:
+        default: 'Unix Makefiles' # TODO: Ninja is much better than makefiles. Should it be the default?
+        description: 'CMake generator'
+        required: false
+        type: string
 
 env:
   BACKWARDS_COMPATIBILITY_ARRAYS: OFF
+  CMAKE_GENERATOR: ${{ inputs.cmake_generator }}
   TILEDB_CI_BACKEND: ${{ inputs.ci_backend }}
   TILEDB_CI_OS: runner.os
   # Installing Python does not work on manylinux.
@@ -123,6 +129,11 @@ jobs:
         with:
           python-version: '3.8'
           cache: 'pip'
+
+      # This must happen after checkout, because checkout would remove the directory.
+      - name: Install Ninja
+        if: inputs.cmake_generator == 'Ninja'
+        uses: seanmiddleditch/gha-setup-ninja@v4
 
       - name: 'Set up Python dependencies'
         if: ${{ !inputs.manylinux }}

--- a/.github/workflows/ci-linux_mac.yml
+++ b/.github/workflows/ci-linux_mac.yml
@@ -60,7 +60,7 @@ on:
 env:
   BACKWARDS_COMPATIBILITY_ARRAYS: OFF
   TILEDB_CI_BACKEND: ${{ inputs.ci_backend }}
-  TILEDB_CI_OS: ${{ startsWith(inputs.matrix_image, 'ubuntu-') && 'Linux' || 'macOS' }}
+  TILEDB_CI_OS: runner.os
   # Installing Python does not work on manylinux.
   TILEDB_ARROW_TESTS: ${{ !inputs.manylinux && 'ON' || 'OFF' }}
   TILEDB_MANYLINUX: ${{ !inputs.manylinux && 'ON' || 'OFF' }}
@@ -121,7 +121,7 @@ jobs:
         uses: actions/setup-python@v4
         if: ${{ !inputs.manylinux }}
         with:
-          python-version: '3.9'
+          python-version: '3.8'
           cache: 'pip'
 
       - name: 'Set up Python dependencies'

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -57,7 +57,7 @@ jobs:
     uses: ./.github/workflows/ci-linux_mac.yml
     with:
       ci_backend: S3
-      matrix_image: macos-12
+      matrix_image: macos-14
       timeout: 120
       bootstrap_args: '--enable=s3,serialization,tools --enable-release-symbols'
 
@@ -65,7 +65,7 @@ jobs:
     uses: ./.github/workflows/ci-linux_mac.yml
     with:
       ci_backend: GCS
-      matrix_image: macos-12
+      matrix_image: macos-14
       timeout: 120
       bootstrap_args: '--enable-gcs --enable-release-symbols'
 
@@ -99,7 +99,7 @@ jobs:
     uses: ./.github/workflows/ci-linux_mac.yml
     with:
       ci_backend: AZURE
-      matrix_image: macos-12
+      matrix_image: macos-14
       timeout: 120
       bootstrap_args: '--enable-azure'
 

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -58,6 +58,7 @@ jobs:
     with:
       ci_backend: S3
       matrix_image: macos-14
+      vcpkg_base_triplet: arm64-osx
       timeout: 120
       bootstrap_args: '--enable=s3,serialization,tools --enable-release-symbols'
 
@@ -66,6 +67,7 @@ jobs:
     with:
       ci_backend: GCS
       matrix_image: macos-14
+      vcpkg_base_triplet: arm64-osx
       timeout: 120
       bootstrap_args: '--enable-gcs --enable-release-symbols'
 
@@ -100,6 +102,7 @@ jobs:
     with:
       ci_backend: AZURE
       matrix_image: macos-14
+      vcpkg_base_triplet: arm64-osx
       timeout: 120
       bootstrap_args: '--enable-azure'
 

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -58,6 +58,7 @@ jobs:
     with:
       ci_backend: S3
       matrix_image: macos-14
+      cmake_generator: 'Ninja' # Use Ninja due to performance issues.
       vcpkg_base_triplet: arm64-osx
       timeout: 120
       bootstrap_args: '--enable=s3,serialization,tools --enable-release-symbols'
@@ -67,6 +68,7 @@ jobs:
     with:
       ci_backend: GCS
       matrix_image: macos-14
+      cmake_generator: 'Ninja' # Use Ninja due to performance issues.
       vcpkg_base_triplet: arm64-osx
       timeout: 120
       bootstrap_args: '--enable-gcs --enable-release-symbols'
@@ -102,6 +104,7 @@ jobs:
     with:
       ci_backend: AZURE
       matrix_image: macos-14
+      cmake_generator: 'Ninja' # Use Ninja due to performance issues.
       vcpkg_base_triplet: arm64-osx
       timeout: 120
       bootstrap_args: '--enable-azure'

--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -69,7 +69,7 @@ jobs:
     uses: ./.github/workflows/ci-linux_mac.yml
     with:
       ci_backend: HDFS
-      matrix_image: ubuntu-24.04
+      matrix_image: ubuntu-22.04
       matrix_compiler_cc: 'gcc-13'
       matrix_compiler_cxx: 'g++-13'
       timeout: 300

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,11 +56,11 @@ jobs:
             triplet: x64-linux-release
             manylinux: true
           - platform: macos-x86_64
-            os: macos-12
+            os: macos-14
             MACOSX_DEPLOYMENT_TARGET: 11
             triplet: x64-osx-release
           - platform: macos-arm64
-            os: macos-12
+            os: macos-14
             cmake_args: -DCMAKE_OSX_ARCHITECTURES=arm64
             MACOSX_DEPLOYMENT_TARGET: 11
             triplet: arm64-osx-release

--- a/scripts/ci/bootstrap_libtiledb.sh
+++ b/scripts/ci/bootstrap_libtiledb.sh
@@ -25,17 +25,6 @@
 #
 set -xeuo pipefail
 
-# Check for clean configure with tests disabled
-# This will not validate linkage, but we can't
-# build all variations separately right now.
-
-CONFIG_TMP_PATH=`mktemp -d`
-pushd $CONFIG_TMP_PATH
-$GITHUB_WORKSPACE/bootstrap $bootstrap_args --disable-tests
-popd
-
-###############################################
-
 # Build and test libtiledb
 
 # Set up arguments for bootstrap.sh

--- a/scripts/ci/build_benchmarks.sh
+++ b/scripts/ci/build_benchmarks.sh
@@ -30,5 +30,5 @@ pushd $GITHUB_WORKSPACE/test/benchmarking
 mkdir -p build
 cd build
 cmake -DCMAKE_PREFIX_PATH="$GITHUB_WORKSPACE/build/dist;$GITHUB_WORKSPACE/build/vcpkg_installed/$VCPKG_TARGET_TRIPLET" ../src
-make
+cmake --build .
 popd

--- a/scripts/ci/build_libtiledb.sh
+++ b/scripts/ci/build_libtiledb.sh
@@ -37,7 +37,7 @@ make -C tiledb install
 
 ls -la
 
-make -j4 -C tiledb tiledb_unit
-make -j4 -C tiledb unit_vfs
-make -j4 -C tiledb tiledb_regression
-make -j4 -C tiledb all_link_complete
+make VERBOSE=1 -j4 -C tiledb tiledb_unit
+make VERBOSE=1 -j4 -C tiledb unit_vfs
+make VERBOSE=1 -j4 -C tiledb tiledb_regression
+make VERBOSE=1 -j4 -C tiledb all_link_complete

--- a/scripts/ci/build_libtiledb.sh
+++ b/scripts/ci/build_libtiledb.sh
@@ -31,13 +31,13 @@ set -xeuo pipefail
 
 cd $GITHUB_WORKSPACE/build
 
-make -j4
+cmake --build . -j4
 
-make -C tiledb install
+cmake --build tiledb --target install
 
 ls -la
 
-make VERBOSE=1 -j4 -C tiledb tiledb_unit
-make VERBOSE=1 -j4 -C tiledb unit_vfs
-make VERBOSE=1 -j4 -C tiledb tiledb_regression
-make VERBOSE=1 -j4 -C tiledb all_link_complete
+cmake --build tiledb -j4 --target tiledb_unit
+cmake --build tiledb -j4 --target unit_vfs
+cmake --build tiledb -j4 --target tiledb_regression
+cmake --build tiledb -j4 --target all_link_complete


### PR DESCRIPTION
See TileDB-Inc#5069.

---
TYPE: NO_HISTORY | FEATURE | BUG | IMPROVEMENT | DEPRECATION | C_API | CPP_API | BREAKING_BEHAVIOR | BREAKING_API | FORMAT
DESC: <short description>
